### PR TITLE
show an error if we fail to make a new user, also show the reason

### DIFF
--- a/UnlockDNN.aspx
+++ b/UnlockDNN.aspx
@@ -36,7 +36,13 @@
             var user = new UserInfo { Username = cp_Username.Text, IsSuperUser = true };
             user.Membership.Approved = true;
             user.Membership.Password = cp_Password.Text;
-            UserController.CreateUser(ref user);
+            var result = UserController.CreateUser(ref user);
+
+            if((int)result == 13){
+                ResultJson = String.Format("{{ Message: 'User has been created', Status: 'Success' }}");
+            }else{
+                ResultJson = string.Format("{{ Message: 'Error creating user: {0}', Status: 'Error' }}", result);
+            }
 
 
             ResultJson = String.Format("{{ Message: 'User has been created', Status: 'Success' }}");


### PR DESCRIPTION
When creating a new user, it can silently fail but still show an success message. For example if the portal is enforcing user accounts need an email address when the portal is configured to use email as username.

This commit/pull request just show the result if we don't have a success result to the user to at least give them a heads up